### PR TITLE
Updating to current CE patch variables

### DIFF
--- a/1.2/Patches/CombatExtended.xml
+++ b/1.2/Patches/CombatExtended.xml
@@ -18,7 +18,7 @@
                                     <li>Poke</li>
                                 </capacities>
                                 <power>8</power>
-				<armorPenetrationBlunt>0.425</armorPenetrationBlunt> <!--same as CE gladius-->
+				<armorPenetrationBlunt>0.425</armorPenetrationBlunt><!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -29,8 +29,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>14</power>
-					<armorPenetrationBlunt>0.956</armorPenetrationBlunt>> <!--same as CE gladius-->
-					<armorPenetrationSharp>0.43</armorPenetrationSharp> <!--same as CE gladius-->
+					<armorPenetrationBlunt>0.956</armorPenetrationBlunt><!--same as CE gladius-->
+					<armorPenetrationSharp>0.43</armorPenetrationSharp><!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                             </li>
@@ -72,7 +72,7 @@
                                     <li>Poke</li>
                                 </capacities>
                                 <power>8</power>
-				<armorPenetrationBlunt>0.425</armorPenetrationBlunt> <!--same as CE gladius-->
+				<armorPenetrationBlunt>0.425</armorPenetrationBlunt><!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -83,8 +83,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>14</power>
-				<armorPenetrationBlunt>0.956</armorPenetrationBlunt>> <!--same as CE gladius-->
-				<armorPenetrationSharp>0.46</armorPenetrationSharp> <!--same as CE ikwa-->
+				<armorPenetrationBlunt>0.956</armorPenetrationBlunt><!--same as CE gladius-->
+				<armorPenetrationSharp>0.46</armorPenetrationSharp><!--same as CE ikwa-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                             </li>
@@ -126,7 +126,7 @@
                                     <li>Blunt</li>
                                 </capacities>
                                 <power>6</power>
-				<armorPenetrationBlunt>0.250</armorPenetrationBlunt> <!--same as CE knife-->
+				<armorPenetrationBlunt>0.250</armorPenetrationBlunt><!--same as CE knife-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -178,7 +178,7 @@
                                     <li>Blunt</li>
                                 </capacities>
                                 <power>6</power>
-				<armorPenetrationBlunt>0.250</armorPenetrationBlunt> <!--same as CE knife-->
+				<armorPenetrationBlunt>0.250</armorPenetrationBlunt><!--same as CE knife-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -189,8 +189,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>10.7</power>
-				<armorPenetrationBlunt>1</armorPenetrationBlunt> <!--same as CE club handle poke-->
-				<armorPenetrationSharp>0.42</armorPenetrationSharp> <!--same as CE knife stab-->
+				<armorPenetrationBlunt>1</armorPenetrationBlunt><!--same as CE club handle poke-->
+				<armorPenetrationSharp>0.42</armorPenetrationSharp><!--same as CE knife stab-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
                             </li>

--- a/1.2/Patches/CombatExtended.xml
+++ b/1.2/Patches/CombatExtended.xml
@@ -18,7 +18,7 @@
                                     <li>Poke</li>
                                 </capacities>
                                 <power>8</power>
-                                <armorPenetration>0.075</armorPenetration>
+				<armorPenetrationBlunt>0.425</armorPenetrationBlunt> <!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -29,7 +29,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>14</power>
-                                <armorPenetration>0.142</armorPenetration>
+					<armorPenetrationBlunt>0.956</armorPenetrationBlunt>> <!--same as CE gladius-->
+					<armorPenetrationSharp>0.43</armorPenetrationSharp> <!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                             </li>
@@ -71,7 +72,7 @@
                                     <li>Poke</li>
                                 </capacities>
                                 <power>8</power>
-                                <armorPenetration>0.075</armorPenetration>
+				<armorPenetrationBlunt>0.425</armorPenetrationBlunt> <!--same as CE gladius-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -82,7 +83,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>14</power>
-                                <armorPenetration>0.266</armorPenetration>
+				<armorPenetrationBlunt>0.956</armorPenetrationBlunt>> <!--same as CE gladius-->
+				<armorPenetrationSharp>0.46</armorPenetrationSharp> <!--same as CE ikwa-->
                                 <cooldownTime>2</cooldownTime>
                                 <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                             </li>
@@ -124,7 +126,7 @@
                                     <li>Blunt</li>
                                 </capacities>
                                 <power>6</power>
-                                <armorPenetration>0.087</armorPenetration>
+				<armorPenetrationBlunt>0.250</armorPenetrationBlunt> <!--same as CE knife-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -135,7 +137,7 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>10.7</power>
-                                <armorPenetration>0.123</armorPenetration>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt><!--same as CE club handle poke-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
                             </li>
@@ -176,7 +178,7 @@
                                     <li>Blunt</li>
                                 </capacities>
                                 <power>6</power>
-                                <armorPenetration>0.087</armorPenetration>
+				<armorPenetrationBlunt>0.250</armorPenetrationBlunt> <!--same as CE knife-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
                             </li>
@@ -187,7 +189,8 @@
                                 </capacities>
                                 <chanceFactor>1.33</chanceFactor>
                                 <power>10.7</power>
-                                <armorPenetration>0.119</armorPenetration>
+				<armorPenetrationBlunt>1</armorPenetrationBlunt> <!--same as CE club handle poke-->
+				<armorPenetrationSharp>0.42</armorPenetrationSharp> <!--same as CE knife stab-->
                                 <cooldownTime>1.55</cooldownTime>
                                 <linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
                             </li>


### PR DESCRIPTION
ArmorPenetration is no longer used as a CE variable.

Used the stats of vanilla melee weapons to add in the armor penetration blunt and sharp terms that are currently used by combat extended (i.e. armorPenetrationBlunt and armorPenetrationSharp).